### PR TITLE
chore: use kc_url as env for health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/health/ready"]
+      test: ["CMD", "curl", "--fail", "${KC_URL}/health/ready"]
     environment: *environment
     ports:
       - ${KC_PORT}:8080


### PR DESCRIPTION
Use the env variable for the health check
<img width="1160" alt="Screenshot 2022-11-11 at 22 32 28" src="https://user-images.githubusercontent.com/60711758/201439813-8e58b1c3-4a86-4459-857a-7792bf7c3e24.png">
