### PR TITLE
fix: comments in .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,17 +1,23 @@
-POSTGRES_VERSION=14.6-alpine # https://www.postgresql.org/docs/release
+# https://www.postgresql.org/docs/release
+POSTGRES_VERSION=14.6-alpine 
 
-KC_VERSION=20.0.2 # https://github.com/keycloak/keycloak/releases
-KC_URL=http://localhost:8080 # The link that will be used by the Grafana to redirect to the Keycloak
+# https://github.com/keycloak/keycloak/releases
+KC_VERSION=20.0.2
+# The link that will be used by the Grafana to redirect to the Keycloak
+KC_URL=http://localhost:8080 
 KC_PORT=8080
-KC_FEATURES=impersonation # https://www.keycloak.org/server/features
+# https://www.keycloak.org/server/features
+KC_FEATURES=impersonation 
 KC_REALM_NAME=grafana
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=keycloak
 
-PROMETHEUS_VERSION=v2.40.7 # https://github.com/prometheus/prometheus/releases
+# https://github.com/prometheus/prometheus/releases
+PROMETHEUS_VERSION=v2.40.7 
 PROMETHEUS_PORT=9090
 
-GF_VERSION=9.3.1 # https://github.com/grafana/grafana/releases
+# https://github.com/grafana/grafana/releases
+GF_VERSION=9.3.1 
 GF_SERVER_HTTP_PORT=3000
 GF_HOSTNAME=http://localhost
 GF_ADMIN_USERNAME=admin


### PR DESCRIPTION
if we use comment in same line with env definition we get invalid reference format error. So, I moved them to beginning of the line.